### PR TITLE
Integrate backend in frontend

### DIFF
--- a/abyss-watcher/package.json
+++ b/abyss-watcher/package.json
@@ -15,6 +15,7 @@
     "d3-tip": "^0.9.1",
     "d3-transition": "^1.1.1",
     "d3-zoom": "^1.7.1",
+    "debounce": "^1.1.0",
     "ndjson-cli": "^0.3.1",
     "rc-slider": "^8.6.1",
     "react": "^16.3.0",

--- a/abyss-watcher/src/Components/DisastersParent.js
+++ b/abyss-watcher/src/Components/DisastersParent.js
@@ -10,33 +10,56 @@ import { feature } from 'topojson-client'
 import * as d3 from 'd3'
 import '../Stylesheets/DisastersParent.css'
 import d3Tip from 'd3-tip'
-// import plotTsunamiPoints from '../D3/Tsunami'
+import plotTsunamiPoints from '../D3/Tsunami'
 import plotEarthquakePoints from '../D3/Earthquake'
 // import plotVolcanoPoints from '../D3/Volcano'
-import plotTornadoPoints from '../D3/Tornado'
-
+// import plotTornadoPoints from '../D3/Tornado'
+  
 /*----------------Components---------------------*/
 import GraphIcon from '../Icons/graph'
 import IconButton from './IconButton'
 
 /*----------------Redux---------------------*/
 import { connect } from 'react-redux';
-
+import {bindActionCreators} from 'redux';
 import { Link } from 'react-router-dom'
+
+/*---------------Actions--------------------*/
+import { getEarthquakesByYear } from '../actions/MenuActions'
 
 class DisastersParent extends Component {
 	constructor(props){
 		super(props)
 	}
 
-	componentDidMount(){
+	async componentDidMount(){
+		// var earthquake_data = await this.getDisasterData();
+  //  		this.earthquake_data = earthquake_data;
+   		// console.log(this.earthquake_data);
 		var newWorldData = this.prepareWorldNamesData();
 		this.newWorldData = newWorldData;
 		this.createMap();
 	}
 
-   	componentDidUpdate() {
+   	async componentDidUpdate() {
+   		// this.earthquake_data = await this.getDisasterData();
 		this.createMap();
+   	}
+
+   	async getDisasterData(){
+   		const { 
+			earthquake_options, 
+			tsunami_options,
+			tornado_options,
+			storm_options,
+			hurricane_options,
+			volcano_options,
+			year
+		} = this.props.selectionData;
+
+   		await this.props.getEarthquakesByYear(year);
+   		var earthquake_data = this.props.disastersData.static_earthquake_data;
+   		return earthquake_data;
    	}
 
 	createMap = () => {
@@ -158,13 +181,13 @@ class DisastersParent extends Component {
 		state_names_g.append("g")
 			.attr("class", "us_states_names");
 
-		plotEarthquakePoints(node, geoPath, earthquake_options.visible, this.CreateYearFilter(year, year));
+		// plotEarthquakePoints(node, geoPath, this.earthquake_data);
 
-		// plotTsunamiPoints(node, geoPath, tsunami_options.visible, this.CreateYearFilter(year, year));
+		plotTsunamiPoints(node, geoPath, tsunami_options.visible, this.CreateYearFilter(year, year));
 
 		// plotVolcanoPoints(node, geoPath, volcano_options.visible, this.CreateYearFilter(year, year));
 
-		plotTornadoPoints(node, geoPath, tornado_options.visible, this.CreateYearFilter(year, year));
+		// plotTornadoPoints(node, geoPath, tornado_options.visible, this.CreateYearFilter(year, year));
 		// zoom capability
 		var zoom = d3.zoom()
 		    .scaleExtent([1, 20])
@@ -223,8 +246,15 @@ class DisastersParent extends Component {
 
 const mapStateToProps = (state) => {
 	return {
-		selectionData: state.menuOptions
+		selectionData: state.menuOptions,
+		disastersData: state.disastersData
 	}
 }
 
-export default connect(mapStateToProps)(DisastersParent);
+const mapDispatchToProps = (dispatch) => {
+	return bindActionCreators({
+		getEarthquakesByYear: getEarthquakesByYear, 
+	}, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(DisastersParent);

--- a/abyss-watcher/src/Components/DisastersParent.js
+++ b/abyss-watcher/src/Components/DisastersParent.js
@@ -12,8 +12,8 @@ import '../Stylesheets/DisastersParent.css'
 import d3Tip from 'd3-tip'
 import plotTsunamiPoints from '../D3/Tsunami'
 import plotEarthquakePoints from '../D3/Earthquake'
-// import plotVolcanoPoints from '../D3/Volcano'
-// import plotTornadoPoints from '../D3/Tornado'
+import plotVolcanoPoints from '../D3/Volcano'
+import plotTornadoPoints from '../D3/Tornado'
   
 /*----------------Components---------------------*/
 import GraphIcon from '../Icons/graph'
@@ -25,28 +25,32 @@ import {bindActionCreators} from 'redux';
 import { Link } from 'react-router-dom'
 
 /*---------------Actions--------------------*/
-import { getEarthquakesByYear } from '../actions/MenuActions'
+import { getEarthquakesByYear, getTsunamisByYear, getTornadoesByYear, getVolcanoesByYear } from '../actions/MenuActions'
 
 class DisastersParent extends Component {
 	constructor(props){
 		super(props)
 	}
 
-	async componentDidMount(){
-		var earthquake_data = await this.getDisasterData();
-   		this.earthquake_data = earthquake_data;
-   		console.log(this.earthquake_data);
+	componentDidMount(){
+		this.getProps();
+		this.props.getEarthquakesByYear(this.year);
+   		this.props.getTsunamisByYear(this.year);
+   		this.props.getTornadoesByYear(this.year);
+   		this.props.getVolcanoesByYear(this.year);
+
 		var newWorldData = this.prepareWorldNamesData();
 		this.newWorldData = newWorldData;
+
 		this.createMap();
 	}
 
-   	async componentDidUpdate() {
-   		// this.earthquake_data = await this.getDisasterData();
+   	componentDidUpdate() {
+   		this.getProps();
 		this.createMap();
    	}
 
-   	async getDisasterData(){
+   	getProps(){
    		const { 
 			earthquake_options, 
 			tsunami_options,
@@ -57,24 +61,30 @@ class DisastersParent extends Component {
 			year
 		} = this.props.selectionData;
 
-   		await this.props.getEarthquakesByYear(year);
-   		var earthquake_data = this.props.disastersData.static_earthquake_data;
-   		return earthquake_data;
+		const { 
+			static_earthquake_data,
+			static_tsunami_data,
+			static_tornado_data,
+			static_volcano_data,
+		} = this.props.disastersData;
+
+		this.earthquake_options = earthquake_options;
+		this.tsunami_options = tsunami_options;
+		this.volcano_options = volcano_options;
+		this.tornado_options = tornado_options;
+
+		this.static_tsunami_data = static_tsunami_data;
+		this.static_earthquake_data = static_earthquake_data;
+		this.static_volcano_data = static_volcano_data;
+		this.static_tornado_data = static_tornado_data;
+
+		this.year = year;
    	}
 
 	createMap = () => {
     	const node = this.node;
     	var width = window.innerWidth;
 		var height = window.innerHeight;
-		const { 
-			earthquake_options, 
-			tsunami_options,
-			tornado_options,
-			storm_options,
-			hurricane_options,
-			volcano_options,
-			year
-		} = this.props.selectionData;
 
 		select(node).selectAll("g").remove();
 
@@ -181,13 +191,13 @@ class DisastersParent extends Component {
 		state_names_g.append("g")
 			.attr("class", "us_states_names");
 
-		// plotEarthquakePoints(node, geoPath, this.earthquake_data);
+		plotEarthquakePoints(node, geoPath, this.earthquake_options.visible, this.static_earthquake_data);
 
-		plotTsunamiPoints(node, geoPath, tsunami_options.visible, this.CreateYearFilter(year, year));
+		plotTsunamiPoints(node, geoPath, this.tsunami_options.visible, this.static_tsunami_data);
 
-		// plotVolcanoPoints(node, geoPath, volcano_options.visible, this.CreateYearFilter(year, year));
+		plotVolcanoPoints(node, geoPath, this.volcano_options.visible, this.static_volcano_data);
 
-		// plotTornadoPoints(node, geoPath, tornado_options.visible, this.CreateYearFilter(year, year));
+		plotTornadoPoints(node, geoPath, this.tornado_options.visible, this.static_tornado_data);
 		// zoom capability
 		var zoom = d3.zoom()
 		    .scaleExtent([1, 20])
@@ -254,6 +264,9 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => {
 	return bindActionCreators({
 		getEarthquakesByYear: getEarthquakesByYear, 
+		getTsunamisByYear: getTsunamisByYear,
+		getTornadoesByYear: getTornadoesByYear,
+		getVolcanoesByYear: getVolcanoesByYear,
 	}, dispatch);
 }
 

--- a/abyss-watcher/src/Components/DisastersParent.js
+++ b/abyss-watcher/src/Components/DisastersParent.js
@@ -33,9 +33,9 @@ class DisastersParent extends Component {
 	}
 
 	async componentDidMount(){
-		// var earthquake_data = await this.getDisasterData();
-  //  		this.earthquake_data = earthquake_data;
-   		// console.log(this.earthquake_data);
+		var earthquake_data = await this.getDisasterData();
+   		this.earthquake_data = earthquake_data;
+   		console.log(this.earthquake_data);
 		var newWorldData = this.prepareWorldNamesData();
 		this.newWorldData = newWorldData;
 		this.createMap();

--- a/abyss-watcher/src/Components/Main.js
+++ b/abyss-watcher/src/Components/Main.js
@@ -7,12 +7,22 @@ import ScaleMenu from './ScaleMenu';
 import { connect } from 'react-redux';
 import {bindActionCreators} from 'redux';
 /*----------------Actions------------------*/
-import { setYear } from '../actions/MenuActions'
+import { setYear, getEarthquakesByYear, getTsunamisByYear, getVolcanoesByYear, getTornadoesByYear } from '../actions/MenuActions'
 /*----------------React Router-------------*/
 import { Switch, Route, withRouter } from 'react-router-dom'
+/*----------------Utils---------------------*/
+import debounce from 'debounce'
 
 
 class Main extends Component {
+	changeYear = debounce((year) => {
+		this.props.setYear(year);
+		this.props.getEarthquakesByYear(year);
+		this.props.getTsunamisByYear(year);
+		this.props.getVolcanoesByYear(year);
+		this.props.getTornadoesByYear(year);
+	}, 150)
+
 	render() {
 		const { year } = this.props.selectionData
 		return (
@@ -28,7 +38,7 @@ class Main extends Component {
 				    </Switch>    
 					<YearSlider
 						defaultValue={ year }
-						onChange={ this.props.setYear }
+						onChange={ this.changeYear }
 					/>
 				</div>
 			</div>
@@ -45,6 +55,10 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => {
 	return bindActionCreators({
 		setYear: setYear, 
+		getEarthquakesByYear: getEarthquakesByYear,
+		getTsunamisByYear: getTsunamisByYear,
+		getVolcanoesByYear: getVolcanoesByYear,
+		getTornadoesByYear: getTornadoesByYear,
 	}, dispatch);
 }
 

--- a/abyss-watcher/src/D3/Earthquake.js
+++ b/abyss-watcher/src/D3/Earthquake.js
@@ -6,14 +6,14 @@ import obtainData from '../utils/obtainData'
 
 // expecting the svg node, the path to plot points along, visible boolean, 
 // and a filter function that will define what data points to display
-export default (node, geoPath, earthquake_data) => {
+export default (node, geoPath, visible, earthquake_data) => {
+	if(!visible) {
+		return;
+	}
+	
 	var earthquakes = select(node)
 		.append( "g" )
 		.attr("class", "earthquake_points");
-
-	if(typeof earthquake_data == 'undefined') {
-		return;
-	}
 
 	var earthquake_features = earthquake_data.sort(function(a, b) {
 		return b.properties.Magnitude - a.properties.Magnitude;

--- a/abyss-watcher/src/D3/Earthquake.js
+++ b/abyss-watcher/src/D3/Earthquake.js
@@ -1,22 +1,21 @@
 import { select } from 'd3-selection'
 import * as d3 from 'd3'
 import d3Tip from 'd3-tip'
-import earthquake_data from '../data/earthquake_dataset'
+// import earthquake_data from '../data/earthquake_dataset'
+import obtainData from '../utils/obtainData'
 
 // expecting the svg node, the path to plot points along, visible boolean, 
 // and a filter function that will define what data points to display
-export default (node, geoPath, visible, filter) => {
-	if(!visible) {
-		return;
-	}
-	
+export default (node, geoPath, earthquake_data) => {
 	var earthquakes = select(node)
 		.append( "g" )
 		.attr("class", "earthquake_points");
 
-	var earthquake_features = earthquake_data.earthquake_json.features.filter(function(obj) {
-		return filter(obj.properties.Date);
-	}).sort(function(a, b) {
+	if(typeof earthquake_data == 'undefined') {
+		return;
+	}
+
+	var earthquake_features = earthquake_data.sort(function(a, b) {
 		return b.properties.Magnitude - a.properties.Magnitude;
 	});
 

--- a/abyss-watcher/src/D3/Tornado.js
+++ b/abyss-watcher/src/D3/Tornado.js
@@ -1,11 +1,10 @@
 import { select } from 'd3-selection'
 import * as d3 from 'd3'
 import d3Tip from 'd3-tip'
-import storms_data from '../data/storms_dataset'
 
 // expecting the svg node, the path to plot points along, visible boolean, 
 // and a filter function that will define what data points to display
-export default (node, geoPath, visible, filter) => {
+export default (node, geoPath, visible, tornado_data) => {
 	if(!visible) {
 		return;
 	}
@@ -14,9 +13,7 @@ export default (node, geoPath, visible, filter) => {
 		.append( "g" )
 		.attr("class", "tornado_points");
 
-	var storms_features = storms_data.storms_json.features.filter(function(obj) {
-		return filter('1/1/' + obj.properties.Year) && obj.properties.Latitude.length != 0;
-	}).sort(function(a, b) {
+	var storms_features = tornado_data.sort(function(a, b) {
 		var storm_rect_area_a = parseInt(a.properties.Width) * parseInt(a.properties.Length);
 		var storm_rect_area_b = parseInt(b.properties.Width) * parseInt(b.properties.Length);
 		return storm_rect_area_b - storm_rect_area_a;

--- a/abyss-watcher/src/D3/Tsunami.js
+++ b/abyss-watcher/src/D3/Tsunami.js
@@ -1,11 +1,10 @@
 import { select } from 'd3-selection'
 import * as d3 from 'd3'
-import tsunami_data from '../data/tsunami_dataset'
 import d3Tip from 'd3-tip'
 
 // expecting the svg node, the path to plot points along, visible boolean, 
 // and a filter function that will define what data points to display
-export default (node, geoPath, visible, filter) => {
+export default (node, geoPath, visible, tsunami_data) => {
 	if(!visible) {
 		return;
 	}
@@ -15,9 +14,7 @@ export default (node, geoPath, visible, filter) => {
 		.attr("class", "tsunami_points");
 
 
-	var tsunami_features = tsunami_data.tsunami_json.features.filter(function(obj) {
-		return filter('1/1/' + obj.properties.Year) && obj.properties.Latitude.length != 0;
-	}).sort(function(a, b) {
+	var tsunami_features = tsunami_data.sort(function(a, b) {
 		return b.properties.Max_height - a.properties.Max_height;
 	});
 

--- a/abyss-watcher/src/D3/Volcano.js
+++ b/abyss-watcher/src/D3/Volcano.js
@@ -2,11 +2,10 @@ import { select } from 'd3-selection'
 import * as d3 from 'd3'
 import d3Tip from 'd3-tip'
 import { feature } from 'topojson-client'
-import volcano_with_impacts_data from '../data/volcano_with_impacts_dataset'
 
 // expecting the svg node, the path to plot points along, visible boolean, 
 // and a filter function that will define what data points to display
-export default (node, geoPath, visible, filter) => {
+export default (node, geoPath, visible, volcano_data) => {
 	if(!visible) {
 		return;
 	}
@@ -15,9 +14,7 @@ export default (node, geoPath, visible, filter) => {
 		.append( "g" )
 		.attr("class", "volcano_points");
 
-	var volcano_features = volcano_with_impacts_data.volcano_json.features.filter(function(obj, i) {
-		return filter('1/1/' + obj.properties.Year);
-	}).sort(function(a, b) {
+	var volcano_features = volcano_data.sort(function(a, b) {
 		return b.properties.Elevation - a.properties.Elevation;
 	});
 

--- a/abyss-watcher/src/actions/MenuActions.js
+++ b/abyss-watcher/src/actions/MenuActions.js
@@ -1,4 +1,5 @@
 import obtainData from '../utils/obtainData';
+import strings from '../utils/strings';
 
 export const setEarthquakeOptions = (options) => {
   	return (dispatch) => {
@@ -66,9 +67,39 @@ export const setYear = (year) => {
 
 export const getEarthquakesByYear = (year) => {
   return async (dispatch) => {
-    var data = await obtainData("https://abyss-watcher-backend.herokuapp.com/abyss-watcher/v1/earthquakes?year=" + year.toString());
+    var data = await obtainData(strings.earthquakes_path + year.toString());
     dispatch({
       type: 'SET_EARTHQUAKE_DATA',
+      payload: data,
+    });
+  }
+}
+
+export const getTsunamisByYear = (year) => {
+  return async (dispatch) => {
+    var data = await obtainData(strings.tsunamis_path + year.toString());
+    dispatch({
+      type: 'SET_TSUNAMI_DATA',
+      payload: data,
+    });
+  }
+}
+
+export const getVolcanoesByYear = (year) => {
+  return async (dispatch) => {
+    var data = await obtainData(strings.volcanoes_path + year.toString());
+    dispatch({
+      type: 'SET_VOLCANO_DATA',
+      payload: data,
+    });
+  }
+}
+
+export const getTornadoesByYear = (year) => {
+  return async (dispatch) => {
+    var data = await obtainData(strings.tornadoes_path + year.toString());
+    dispatch({
+      type: 'SET_TORNADO_DATA',
       payload: data,
     });
   }

--- a/abyss-watcher/src/actions/MenuActions.js
+++ b/abyss-watcher/src/actions/MenuActions.js
@@ -1,3 +1,5 @@
+import obtainData from '../utils/obtainData';
+
 export const setEarthquakeOptions = (options) => {
   	return (dispatch) => {
     	dispatch({
@@ -58,6 +60,16 @@ export const setYear = (year) => {
     dispatch({
       type: 'SET_YEAR',
       payload: year,
+    });
+  }
+}
+
+export const getEarthquakesByYear = (year) => {
+  return async (dispatch) => {
+    var data = await obtainData("https://abyss-watcher-backend.herokuapp.com/abyss-watcher/v1/earthquakes?year=" + year.toString());
+    dispatch({
+      type: 'SET_EARTHQUAKE_DATA',
+      payload: data,
     });
   }
 }

--- a/abyss-watcher/src/reducers/DisastersDataReducer.js
+++ b/abyss-watcher/src/reducers/DisastersDataReducer.js
@@ -5,13 +5,18 @@
 
 // "state = null" is set so that we don't throw an error when app first boots up
 
-
 export default function (state = {}, action) {
     var payload = action.payload;
     
     switch (action.type) {
         case 'SET_EARTHQUAKE_DATA':
             return {...state, static_earthquake_data: payload}
+        case 'SET_TSUNAMI_DATA':
+            return {...state, static_tsunami_data: payload}
+        case 'SET_TORNADO_DATA':
+            return {...state, static_tornado_data: payload}
+        case 'SET_VOLCANO_DATA':
+            return {...state, static_volcano_data: payload}
         default:
             break;
     }

--- a/abyss-watcher/src/reducers/DisastersDataReducer.js
+++ b/abyss-watcher/src/reducers/DisastersDataReducer.js
@@ -1,0 +1,19 @@
+/*
+ * All reducers get two parameters passed in, state and action that occurred
+ *       > state isn't entire apps state, only the part of state that this reducer is responsible for
+ * */
+
+// "state = null" is set so that we don't throw an error when app first boots up
+
+
+export default function (state = {}, action) {
+    var payload = action.payload;
+    
+    switch (action.type) {
+        case 'SET_EARTHQUAKE_DATA':
+            return {...state, static_earthquake_data: payload}
+        default:
+            break;
+    }
+    return state;
+}

--- a/abyss-watcher/src/reducers/MenuOptionsReducer.js
+++ b/abyss-watcher/src/reducers/MenuOptionsReducer.js
@@ -24,6 +24,8 @@ export default function (state = {}, action) {
             return {...state, storm_options: payload};
         case 'SET_YEAR':
             return {...state, year: payload };
+        case 'SET_EARTHQUAKE_DATA':
+            return {...state, static_earthquake_data: payload}
         default:
             break;
     }

--- a/abyss-watcher/src/reducers/index.js
+++ b/abyss-watcher/src/reducers/index.js
@@ -2,10 +2,12 @@ import {combineReducers} from 'redux';
 
 /*import your reducers */
 import MenuOptionsReducer from './MenuOptionsReducer';
+import DisastersDataReducer from './DisastersDataReducer';
 
 
 const allReducers = combineReducers({
     menuOptions: MenuOptionsReducer,
+    disastersData: DisastersDataReducer,
 });
 
 export default allReducers 

--- a/abyss-watcher/src/store/index.js
+++ b/abyss-watcher/src/store/index.js
@@ -14,6 +14,9 @@ const defaultStoreValues = {
 		tsunami_options: {type: "TSUNAMIS", visible: false},
 		volcano_options: {type: "VOLCANOES", visible: false},
 		year: 2005,
+	},
+	disastersData: {
+		static_earthquake_data: {},
 	}
 };
 

--- a/abyss-watcher/src/store/index.js
+++ b/abyss-watcher/src/store/index.js
@@ -16,7 +16,10 @@ const defaultStoreValues = {
 		year: 2005,
 	},
 	disastersData: {
-		static_earthquake_data: {},
+		static_earthquake_data: [],
+		static_tsunami_data: [],
+		static_volcanoes_data: [],
+		static_tornadoes_data: [],
 	}
 };
 

--- a/abyss-watcher/src/utils/obtainData.js
+++ b/abyss-watcher/src/utils/obtainData.js
@@ -1,0 +1,4 @@
+export default async function obtainData(url) {
+	const res = await fetch(url);
+	return await res.json();
+}

--- a/abyss-watcher/src/utils/strings.js
+++ b/abyss-watcher/src/utils/strings.js
@@ -1,0 +1,6 @@
+export default {
+	earthquakes_path: "https://abyss-watcher-backend.herokuapp.com/abyss-watcher/v1/earthquakes?year=",
+	tsunamis_path: "https://abyss-watcher-backend.herokuapp.com/abyss-watcher/v1/tsunamis?year=",
+	volcanoes_path: "https://abyss-watcher-backend.herokuapp.com/abyss-watcher/v1/volcanoes?year=",
+	tornadoes_path: "https://abyss-watcher-backend.herokuapp.com/abyss-watcher/v1/tornadoes?year="
+}


### PR DESCRIPTION
backend now used for frontend. needed to apply debounce of 150ms for slider to preclude too many requests from going to backend. All natural disaster types are now making requests to custom Abyss-Watcher-Backend.

TO DO: ENABLE CORS FOR BACKEND. FOR NOW FRONTEND WILL ONLY WORK VIA EXTENSION ENABLING CORS.